### PR TITLE
Replace flatten library

### DIFF
--- a/lib/pg_types.js
+++ b/lib/pg_types.js
@@ -1,6 +1,5 @@
 var ieee754 = require('ieee754');
 var int64 = require('int64-buffer');
-var flatten = require('flatten');
 var BufferPut = require('bufferput');
 
 // bool
@@ -227,6 +226,9 @@ function parse(buf, type) {
   return types[type].recv(buf);
 }
 
+function flatten(arr) {
+  return arr.reduce((acc, val) => Array.isArray(val) ? acc.concat(flatten(val)) : acc.concat(val), []);
+}
 
 module.exports = {
   types:    types,

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,9 +57,9 @@
       "integrity": "sha512-XDBEu44oSTqlvCSiOZ/0FoUkpWu/vwjJLGSKDabNISPQNZ5wub1FodGHBljRsrR0IXRPq7SslshZYMuA55CgTQ=="
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "multi-fork": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "bufferput": "^0.1.3",
-    "flatten": "^1.0.2",
     "ieee754": "^1.1.13",
     "int64-buffer": "^0.99.1007",
     "multi-fork": "0.0.2",

--- a/test/parse.js
+++ b/test/parse.js
@@ -5,7 +5,6 @@ var pgtypes = require('../lib/pg_types');
 var types = pgtypes.types;
 var parse = pgtypes.parse;
 
-var flatten = require('flatten');
 var BP = require('bufferput');
 var samples = require('./samples');
 
@@ -16,6 +15,10 @@ function size(ar){
         row_sizes.push(ar[i].length)
     }
     return [row_count, Math.max.apply(null, row_sizes)]
+}
+
+function flatten(arr) {
+  return arr.reduce((acc, val) => Array.isArray(val) ? acc.concat(flatten(val)) : acc.concat(val), []);
 }
 
 var test_samples = function() {


### PR DESCRIPTION
Hi,

I replaced the flatten library with flatten deep as documented:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat#reduce_and_concat

Implements #3 