### PR TITLE
Support type `varchar`

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ For all supported types, their corresponding array version is also supported.
 - int2, int4
 - float4, float8
 - text
+- varchar
 - json
 - jsonb
 - timestamptz

--- a/lib/pg_types.js
+++ b/lib/pg_types.js
@@ -42,6 +42,10 @@ const textrecv = function (buf) {
   return buf.toString('utf-8')
 }
 
+// varchar
+const varcharsend = textsend
+const varcharrecv = textrecv
+
 // json
 const json_send = function (buf, value) {
   const jbuf = Buffer.from(JSON.stringify(value), 'utf-8')
@@ -193,6 +197,7 @@ const types = {
   int2: { oid: 21, send: int2send, recv: int2recv },
   int4: { oid: 23, send: int4send, recv: int4recv },
   text: { oid: 25, send: textsend, recv: textrecv },
+  varchar: { oid: 1043, send: varcharsend, recv: varcharrecv },
   json: { oid: 114, send: json_send, recv: json_recv },
   jsonb: { oid: 3802, send: jsonb_send, recv: jsonb_recv },
   float4: { oid: 700, send: float4send, recv: float4recv },
@@ -203,6 +208,7 @@ const types = {
   _int2: { oid: 1005, send: array_send.bind(null, 'int2'), recv: array_recv },
   _int4: { oid: 1007, send: array_send.bind(null, 'int4'), recv: array_recv },
   _text: { oid: 1009, send: array_send.bind(null, 'text'), recv: array_recv },
+  _varchar: { oid: 1015, send: array_send.bind(null, 'varchar'), recv: array_recv },
   _json: { oid: 199, send: array_send.bind(null, 'json'), recv: array_recv },
   _jsonb: { oid: 3807, send: array_send.bind(null, 'jsonb'), recv: array_recv },
   _float4: { oid: 1021, send: array_send.bind(null, 'float4'), recv: array_recv },

--- a/test/samples.js
+++ b/test/samples.js
@@ -28,6 +28,9 @@ module.exports = [
   { t: 'text', v: null, r: new BP().word32be(-1).buffer() },
   { t: 'text', v: 'hello', r: new BP().word32be(5).put(Buffer.from('hello')).buffer() },
   { t: 'text', v: 'utf8 éà', r: new BP().word32be(9).put(Buffer.from('utf8 éà', 'utf-8')).buffer() },
+  { t: 'varchar', v: null, r: new BP().word32be(-1).buffer() },
+  { t: 'varchar', v: 'hello', r: new BP().word32be(5).put(Buffer.from('hello')).buffer() },
+  { t: 'varchar', v: 'utf8 éà', r: new BP().word32be(9).put(Buffer.from('utf8 éà', 'utf-8')).buffer() },
   { t: 'json', v: null, r: new BP().word32be(-1).buffer() },
   { t: 'json', v: { a: true, b: [1, 7] }, r: new BP().word32be(20).string('{"a":true,"b":[1,7]}', 'utf-8').buffer() },
   { t: 'jsonb', v: null, r: new BP().word32be(-1).buffer() },
@@ -174,6 +177,25 @@ module.exports = [
       .word32be(1)
       .word32be(0)
       .word32be(types['text'].oid)
+      .word32be(2)
+      .word32be(1)
+      .word32be(2)
+      .word8(97)
+      .word8(98)
+      .word32be(2)
+      .word8(99)
+      .word8(100)
+      .buffer(),
+  },
+  { t: '_varchar', v: null, r: new BP().word32be(-1).buffer() },
+  {
+    t: '_varchar',
+    v: ['ab', 'cd'],
+    r: new BP()
+      .word32be(32)
+      .word32be(1)
+      .word32be(0)
+      .word32be(types['varchar'].oid)
       .word32be(2)
       .word32be(1)
       .word32be(2)


### PR DESCRIPTION
Fixes https://github.com/jeromew/node-pg-copy-streams-binary/issues/15

This is a very mindless adaptation of the existing `text` support, so it'll inherit any bugs that might exist in that.

I confirmed the new unit tests pass.