### PR TITLE
add int8 datatype support

### DIFF
--- a/lib/pg_types.js
+++ b/lib/pg_types.js
@@ -33,6 +33,16 @@ const int4recv = function (buf) {
   return buf.readInt32BE(0)
 }
 
+// int8
+const int8send = function (buf, value) {
+  const tbuf = Buffer.allocUnsafe(8)
+  tbuf.writeBigInt64BE(value)
+  buf.put(tbuf)
+}
+const int8recv = function (buf) {
+  return buf.readBigInt64BE(0)
+}
+
 // text
 const textsend = function (buf, value) {
   const tbuf = Buffer.from(value, 'utf-8')
@@ -197,6 +207,7 @@ const types = {
   bytea: { oid: 17, send: byteasend, recv: bytearecv },
   int2: { oid: 21, send: int2send, recv: int2recv },
   int4: { oid: 23, send: int4send, recv: int4recv },
+  int8: { oid: 20, send: int8send, recv: int8recv },
   text: { oid: 25, send: textsend, recv: textrecv },
   varchar: { oid: 1043, send: varcharsend, recv: varcharrecv },
   json: { oid: 114, send: json_send, recv: json_recv },
@@ -208,6 +219,7 @@ const types = {
   _bytea: { oid: 1001, send: array_send.bind(null, 'bytea'), recv: array_recv },
   _int2: { oid: 1005, send: array_send.bind(null, 'int2'), recv: array_recv },
   _int4: { oid: 1007, send: array_send.bind(null, 'int4'), recv: array_recv },
+  _int8: { oid: 1016, send: array_send.bind(null, 'int8'), recv: array_recv },
   _text: { oid: 1009, send: array_send.bind(null, 'text'), recv: array_recv },
   _varchar: { oid: 1015, send: array_send.bind(null, 'varchar'), recv: array_recv },
   _json: { oid: 199, send: array_send.bind(null, 'json'), recv: array_recv },

--- a/test/fieldReader.js
+++ b/test/fieldReader.js
@@ -1,20 +1,15 @@
 const assert = require('assert')
-const pg = require('pg')
 const { fieldReader } = require('../')
 const { to: copyTo } = require('pg-copy-streams')
 const through2 = require('through2')
 const concat = require('concat-stream')
-
-const getClient = function () {
-  const client = new pg.Client()
-  client.connect()
-  return client
-}
+const { getClient } = require('./utils')
 
 const samples = {
   bool: [null, true, false],
   int2: [23, -59, null],
   int4: [2938, null, -99283],
+  int8: [BigInt(2938), null, BigInt(-99283)],
   text: ['aaa', 'ééé', null],
   json: [JSON.stringify({}), JSON.stringify([1, 2]), null],
   jsonb: [JSON.stringify({}), JSON.stringify([1, 2]), null],

--- a/test/rawReader.js
+++ b/test/rawReader.js
@@ -1,14 +1,8 @@
 const assert = require('assert')
-const pg = require('pg')
 const { rawReader } = require('../')
 const { to: copyTo } = require('pg-copy-streams')
 const concat = require('concat-stream')
-
-const getClient = function () {
-  const client = new pg.Client()
-  client.connect()
-  return client
-}
+const { getClient } = require('./utils')
 
 describe('integration test - rawReader', () => {
   it('stream all raw bytes / small fields including empty and null', (done) => {

--- a/test/rowReader.js
+++ b/test/rowReader.js
@@ -1,21 +1,16 @@
 const assert = require('assert')
-const pg = require('pg')
 const { rowReader } = require('../')
 const { to: copyTo } = require('pg-copy-streams')
 const through2 = require('through2')
 const concat = require('concat-stream')
-
-const getClient = function () {
-  const client = new pg.Client()
-  client.connect()
-  return client
-}
+const { getClient } = require('./utils')
 
 const samples = {
   bool: [null, true, false],
   bytea: [Buffer.from([0x61]), null, Buffer.from([0x62])],
   int2: [23, -59, null],
   int4: [2938, null, -99283],
+  int8: [BigInt(2938), null, BigInt(-99283)],
   text: ['aaa', 'ééé', null],
   json: [JSON.stringify({}), JSON.stringify([1, 2]), null],
   jsonb: [JSON.stringify({}), JSON.stringify({ a: true, b: [4, 2] }), null],

--- a/test/rowWriter.js
+++ b/test/rowWriter.js
@@ -1,14 +1,8 @@
 const assert = require('assert')
 const util = require('util')
-const pg = require('pg')
 const { rowWriter } = require('../')
 const { from: copyFrom } = require('pg-copy-streams')
-
-const getClient = function () {
-  const client = new pg.Client()
-  client.connect()
-  return client
-}
+const { getClient } = require('./utils')
 
 describe('integration test - copyIn', () => {
   it('ingesting an empty flow should not trigger an error', (done) => {
@@ -56,6 +50,23 @@ describe('integration test - copyIn', () => {
         [3, 4],
       ],
       '{{1,2},{3,4}}',
+    ],
+    ['int8', 0, null, null],
+    ['int8', 0, BigInt('501007199254740991'), '501007199254740991'],
+    [
+      'int8',
+      1,
+      [BigInt('501007199254740991'), BigInt('501007199254740999')],
+      '{501007199254740991,501007199254740999}',
+    ],
+    [
+      'int8',
+      2,
+      [
+        [BigInt('501007199254740991'), BigInt('501007199254740999')],
+        [BigInt('501007199254740993'), BigInt('501007199254740994')],
+      ],
+      '{{501007199254740991,501007199254740999},{501007199254740993,501007199254740994}}',
     ],
     ['float4', 0, 0.2736, '0.2736'],
     ['float4', 0, 2.928e27, '2.928e+27'],

--- a/test/samples.js
+++ b/test/samples.js
@@ -7,6 +7,12 @@ BP.prototype.string = function (s, enc) {
   return this.put(buf)
 }
 
+function makeBigIntBuffer(value) {
+  const buf = Buffer.alloc(8)
+  buf.writeBigInt64BE(BigInt(value))
+  return buf
+}
+
 module.exports = [
   // simple types
   { t: 'bool', v: null, r: new BP().word32be(-1).buffer() },
@@ -25,6 +31,12 @@ module.exports = [
   { t: 'int2', v: 128, r: new BP().word32be(2).word16be(128).buffer() },
   { t: 'int4', v: null, r: new BP().word32be(-1).buffer() },
   { t: 'int4', v: 128, r: new BP().word32be(4).word32be(128).buffer() },
+  { t: 'int8', v: null, r: new BP().word32be(-1).buffer() },
+  {
+    t: 'int8',
+    v: BigInt('128'),
+    r: new BP().word32be(8).put(makeBigIntBuffer('128')).buffer(),
+  },
   { t: 'text', v: null, r: new BP().word32be(-1).buffer() },
   { t: 'text', v: 'hello', r: new BP().word32be(5).put(Buffer.from('hello')).buffer() },
   { t: 'text', v: 'utf8 éà', r: new BP().word32be(9).put(Buffer.from('utf8 éà', 'utf-8')).buffer() },
@@ -147,6 +159,32 @@ module.exports = [
       .word32be(5)
       .word32be(4)
       .word32be(6)
+      .buffer(),
+  },
+  { t: '_int8', v: null, r: new BP().word32be(-1).buffer() },
+  {
+    t: '_int8',
+    v: [
+      [BigInt('1'), BigInt('2')],
+      [BigInt('3'), BigInt('4')],
+    ],
+    r: new BP()
+      .word32be(76)
+      .word32be(2)
+      .word32be(0)
+      .word32be(types['int8'].oid)
+      .word32be(2)
+      .word32be(1)
+      .word32be(2)
+      .word32be(1)
+      .word32be(8)
+      .put(makeBigIntBuffer('1'))
+      .word32be(8)
+      .put(makeBigIntBuffer('2'))
+      .word32be(8)
+      .put(makeBigIntBuffer('3'))
+      .word32be(8)
+      .put(makeBigIntBuffer('4'))
       .buffer(),
   },
   { t: '_bytea', v: null, r: new BP().word32be(-1).buffer() },

--- a/test/transform.js
+++ b/test/transform.js
@@ -1,17 +1,11 @@
 const assert = require('assert')
 const async = require('async')
 
-const pg = require('pg')
 const { to: pgCopyTo, from: pgCopyFrom } = require('pg-copy-streams')
 const through2 = require('through2')
 
+const { getClient } = require('./utils')
 const { transform } = require('../')
-
-const getClient = function (dsn) {
-  const client = new pg.Client(dsn)
-  client.connect()
-  return client
-}
 
 describe('integration test - transform', () => {
   it('should correclty extract, transform and load data', (done) => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,9 @@
+const pg = require('pg')
+
+module.exports = {
+  getClient: () => {
+    const client = new pg.Client(process.env.PG_URL)
+    client.connect()
+    return client
+  },
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,7 +2,7 @@ const pg = require('pg')
 
 module.exports = {
   getClient: () => {
-    const client = new pg.Client(process.env.PG_URL)
+    const client = new pg.Client()
     client.connect()
     return client
   },


### PR DESCRIPTION
I've added the support for int8 datatype.

- added tests for int8/_int8 types
- moved getClient util function to separate file
-  load pg connection string from env

i  tried solution from this PR #14, but it worked only for numbers smaller than `Number.MAX_SAFE_INTEGER (2^53 - 1)`, so ireplaced it with proper buffer BigInt operations... so to make it work you have to use `nodejs v12+ or v10.20+